### PR TITLE
fix: hyper-connect import and connect functions

### DIFF
--- a/connect/README.md
+++ b/connect/README.md
@@ -124,7 +124,9 @@ send a full document to hyper.
 In the `api/update-character.js` file, lets re-write the updateCharacter API handler:
 
 ``` js
-import { hyper } from 'hyper-connect'
+import connect from 'hyper-connect'
+
+const hyper = connect(process.env['HYPER'])()
 
 export default async function(req, res) {
   const result = await hyper.data.update(req.params.id, req.body)
@@ -149,7 +151,9 @@ curl -X PUT localhost:3000/api/characters/character-1 \
 To remove a document from a hyper data service, we will use the `data.remove` method. In `api/remove-character.js` lets re-write the function like so:
 
 ``` js
-import { hyper } from 'hyper-connect'
+import connect from 'hyper-connect'
+
+const hyper = connect(process.env['HYPER'])()
 
 export default async function(req, res) {
   const result = await hyper.data.remove(req.params.id)
@@ -216,7 +220,9 @@ documents that are type 'character'
 In your editor open `api/list-characters.js` and re-write the function:
 
 ``` js
-import { hyper } from 'hyper-connect'
+import connect from 'hyper-connect'
+
+const hyper = connect(process.env['HYPER'])()
 
 const byType = doctype => doc => doc.type === doctype
 

--- a/hello-world/README.md
+++ b/hello-world/README.md
@@ -98,7 +98,7 @@ In your editor, open `api/create-characer.js` and lets do the following:
 
 ``` js
 import connect from 'hyper-connect'
-const hyper = connect(process.env['HYPER'])
+const hyper = connect(process.env['HYPER'])()
 ```
 
 - call `data.add` to add the new character document
@@ -133,7 +133,7 @@ In your editor open `api/get-character.js` and do the following:
 
 ``` js
 import connect from 'hyper-connect'
-const hyper = connect(process.env['HYPER'])
+const hyper = connect(process.env['HYPER'])()
 
 export default async function (req, res) {
   const character = await hyper.data.get(req.params.id)

--- a/query/README.md
+++ b/query/README.md
@@ -83,7 +83,10 @@ In the `api/characters/_query.js` file, lets modify the `post` function to perfo
 query.
 
 ``` js
-import { hyper } from 'hyper-connect'
+import connect from 'hyper-connect'
+
+const hyper = connect(process.env['HYPER'])()
+
 
 export async function post(_req, res) {
   // 📝 NOTE: you may want to check if the game_id document exists


### PR DESCRIPTION
In these examples, in order to initialize hyper-connect - you must have fetch and Request available globally.

``` js
import connect from 'hyper-connect'

const hyper = connect(process.env['HYPER'])()

```